### PR TITLE
RMB post form now appears even if the RMB is empty

### DIFF
--- a/nationstates++.js
+++ b/nationstates++.js
@@ -66,7 +66,7 @@ function nationstatesPlusPlus() {
 			//Move the post form to the top
 			var formHtml = "<form method='post' action='/page=lodgermbpost/region=" + region + "' id='rmb'>" + rmbPost.innerHTML + "</form>";
 			rmbPost.parentNode.removeChild(rmbPost);
-			$(formHtml).insertBefore('.rmbrow:first');
+			$(formHtml).insertBefore('.widebox:first');
 		}
 
 		var forumView = jQuery('#content').find('.rmbview');


### PR DESCRIPTION
So I was messing around, and it turns out that if there aren't any RMB posts, the .rmbrow:first class doesn't exist.  As far as I can tell (I've tested on both empty and full RMBs) if you replace it with .widebox:first everything should work, as there isn't anything significant between the first .widebox div and the first .rmbrow div.
