### PR TITLE
Fix Newspaper/IRC display in Regional Controls

### DIFF
--- a/Extension/Chrome/background.js
+++ b/Extension/Chrome/background.js
@@ -74,7 +74,7 @@ function loadJavascript() {
 	if (pageUrl.indexOf('www.nationstates.net/') > -1 || pageUrl.indexOf('rift.nationstates.net/') > -1) {
 		console.log('[NationStates++] Detected NationStates Page. Loading...');
 
-		if (document.head.innerHTML.indexOf("jquery_v1445466141.js") != -1) {
+		if (document.head.innerHTML.search(/jquery_v\d+\.js/) != -1) {
 			addJavascriptString(highchartsAdapter);
 		}
 

--- a/Extension/Chrome/background.js
+++ b/Extension/Chrome/background.js
@@ -74,7 +74,7 @@ function loadJavascript() {
 	if (pageUrl.indexOf('www.nationstates.net/') > -1 || pageUrl.indexOf('rift.nationstates.net/') > -1) {
 		console.log('[NationStates++] Detected NationStates Page. Loading...');
 
-		if (document.head.innerHTML.indexOf("//ajax.googleapis.com/ajax/libs/jquery") != -1) {
+		if (document.head.innerHTML.indexOf("jquery_v1445466141.js") != -1) {
 			addJavascriptString(highchartsAdapter);
 		}
 

--- a/Extension/Firefox/addon/data/background.js
+++ b/Extension/Firefox/addon/data/background.js
@@ -64,7 +64,7 @@ var pageUrl = window.location.href;
 		}
 	}
 
-	if (document.head.innerHTML.indexOf("//ajax.googleapis.com/ajax/libs/jquery") != -1) {
+	if (document.head.innerHTML.search(/jquery_v\d+\.js/) != -1) {
 		addJavascriptString(googleAnalytics);
 	}
 

--- a/Extension/Firefox/addon/data/background.js
+++ b/Extension/Firefox/addon/data/background.js
@@ -64,7 +64,7 @@ var pageUrl = window.location.href;
 		}
 	}
 
-	if (document.head.innerHTML.search(/jquery_v\d+\.js/) != -1) {
+	if (document.head.innerHTML.indexOf("//ajax.googleapis.com/ajax/libs/jquery") != -1) {
 		addJavascriptString(googleAnalytics);
 	}
 
@@ -79,7 +79,7 @@ function loadJavascript() {
 	if (pageUrl.indexOf('www.nationstates.net/') > -1) {
 		console.log('[NationStates++] Detected NationStates Page. Loading...');
 
-		if (document.head.innerHTML.indexOf("jquery_v1445466141.js") != -1) {
+		if (document.head.innerHTML.search(/jquery_v\d+\.js/) != -1) {
 			addJavascriptString(highchartsAdapter);
 		}
 

--- a/Extension/Firefox/addon/data/background.js
+++ b/Extension/Firefox/addon/data/background.js
@@ -79,7 +79,7 @@ function loadJavascript() {
 	if (pageUrl.indexOf('www.nationstates.net/') > -1) {
 		console.log('[NationStates++] Detected NationStates Page. Loading...');
 
-		if (document.head.innerHTML.indexOf("//ajax.googleapis.com/ajax/libs/jquery") != -1) {
+		if (document.head.innerHTML.indexOf("jquery_v1445466141.js") != -1) {
 			addJavascriptString(highchartsAdapter);
 		}
 

--- a/Extension/Safari/nationstates++.safariextension/background.js
+++ b/Extension/Safari/nationstates++.safariextension/background.js
@@ -72,7 +72,7 @@ function loadJavascript() {
 	if (pageUrl.indexOf('www.nationstates.net/') > -1) {
 		console.log('[NationStates++] Detected NationStates Page. Loading...');
 
-		if (document.head.innerHTML.indexOf("//ajax.googleapis.com/ajax/libs/jquery") != -1) {
+		if (document.head.innerHTML.indexOf("jquery_v1445466141.js") != -1) {
 			addJavascriptString(highchartsAdapter);
 		}
 

--- a/Extension/Safari/nationstates++.safariextension/background.js
+++ b/Extension/Safari/nationstates++.safariextension/background.js
@@ -72,7 +72,7 @@ function loadJavascript() {
 	if (pageUrl.indexOf('www.nationstates.net/') > -1) {
 		console.log('[NationStates++] Detected NationStates Page. Loading...');
 
-		if (document.head.innerHTML.indexOf("jquery_v1445466141.js") != -1) {
+		if (document.head.innerHTML.search(/jquery_v\d+\.js/) != -1) {
 			addJavascriptString(highchartsAdapter);
 		}
 

--- a/Extension/js/administration.js
+++ b/Extension/js/administration.js
@@ -6,7 +6,7 @@
 		var nsppIcon = "<span style='font-size:12px' title='This is a setting that is provided by the NationStates++ extension'>(NS<i class='fa fa-plus'></i><i class='fa fa-plus'></i>) </span>";
 		
 		//Found Newspaper button
-		$("<div id='regional_newspaper'></div>").insertBefore("h4:contains('Welcome Telegrams')");
+		$("<div id='regional_newspaper'></div>").prependTo(":header:contains('Communications') + .divindent");
 		$("#regional_newspaper").html("<h4>" + nsppIcon + "Regional Newspaper</h4>");
 		$.get("https://nationstatesplusplus.net/api/newspaper/region/?region=" + getVisibleRegion() + "&time=" + Date.now(), function(data) {
 			$("#regional_newspaper").append("<button id='disband_news' class='button danger'>Disband Regional Newspaper</button><span id='lack_authority' style='display:none;margin-left: 5px;color:red;'>You do not have authority to disband.</span><span id='disbanded_success' style='display:none;margin-left: 5px;color:green;'>The regional newspaper has been disbanded.</span>");


### PR DESCRIPTION
changed display of newspaper/IRC controls in Regional Controls to
display in the Communications tab, not floating above the sidebar.

changed background.js to check for current NS implementation of jquery, which fixes custom Highcharts including regional population and WA statistics